### PR TITLE
Fix: allow prerelease version for peerDependency to ui-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "styled-components": "6.1.15"
   },
   "peerDependencies": {
-    "@kibalabs/ui-react": ">=0.11.2",
+    "@kibalabs/ui-react": ">=0.11.2 || >=0.11.3-next",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
     "styled-components": "^6.1.15"


### PR DESCRIPTION
<!--- Title format: [Feature | Fix | Task#]: <summary of your changes> -->

## Description

<!--- Describe your changes -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots:

<!--- If not relevant delete the sub-heading above -->

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] I have updated the documentation accordingly
<!-- - [ ] My changes have tests around them -->
